### PR TITLE
METDEV-1267 Edit-page: Encapsulate screen width selection items into a dropdown menu

### DIFF
--- a/admin-base/core/src/main/java/com/peregrine/admin/models/MaterialIconDropdownModel.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/models/MaterialIconDropdownModel.java
@@ -1,0 +1,44 @@
+package com.peregrine.admin.models;
+
+import com.peregrine.nodetypes.models.Container;
+import com.peregrine.nodetypes.models.IComponent;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.models.annotations.DefaultInjectionStrategy;
+import org.apache.sling.models.annotations.Exporter;
+import org.apache.sling.models.annotations.Model;
+
+import javax.inject.Inject;
+
+import static com.peregrine.admin.util.AdminConstants.MATERIAL_ICON_DROPDOWN_COMPONENT_PATH;
+import static com.peregrine.commons.util.PerConstants.JACKSON;
+import static com.peregrine.commons.util.PerConstants.JSON;
+
+
+@Model(
+    adaptables = Resource.class,
+    resourceType = MATERIAL_ICON_DROPDOWN_COMPONENT_PATH,
+    defaultInjectionStrategy = DefaultInjectionStrategy.OPTIONAL,
+    adapters = IComponent.class
+)
+@Exporter(name = JACKSON,
+    extensions = JSON)
+
+public class MaterialIconDropdownModel extends Container {
+
+
+  public MaterialIconDropdownModel(Resource r) { super(r); }
+
+  @Inject
+  private String title;
+
+  @Inject String icon;
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getIcon() {
+    return icon;
+  }
+}
+

--- a/admin-base/core/src/main/java/com/peregrine/admin/util/AdminConstants.java
+++ b/admin-base/core/src/main/java/com/peregrine/admin/util/AdminConstants.java
@@ -14,6 +14,7 @@ public class AdminConstants {
     public static final String EXTENSION_COMPONENT_PATH = "admin/components/extensions";
     public static final String ICON_ACTION_COMPONENT_PATH = "admin/components/iconaction";
     public static final String ICON_LIST_COMPONENT_PATH = "admin/components/iconlist";
+    public static final String MATERIAL_ICON_DROPDOWN_COMPONENT_PATH = "admin/components/materialicondropdown";
     public static final String NAV_COMPONENT_PATH = "admin/components/nav";
     public static final String TOOLING_PAGE_COMPONENT_PATH = "admin/components/toolingpage";
     public static final String PATH_FIELD_COMPONENT_PATH = "admin/components/pathfield";

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/action/template.vue
@@ -185,9 +185,13 @@
 }
 </script>
 
-<style>
+<style scoped>
     .actionSelected {
         background-color: white !important;
         color: #37474f !important;
+    }
+
+    .material-icons {
+        line-height: 40px;
     }
 </style>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/.content.xml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/.content.xml
@@ -1,0 +1,4 @@
+<jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0" xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
+  jcr:primaryType="per:Component"
+  jcr:title="dropdown"
+/>

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
@@ -1,0 +1,75 @@
+<template>
+  <div class="drpdwn" v-bind:data-per-path="model.path">
+    <button class="drpbtn">
+      <a title="screen-dropdown" class="btn-floating waves-effect waves-light">
+        <i class="material-icons">{{icon}}</i>
+      </a>
+    </button>
+    <div class="drpdwn-content" >
+      <template v-for="child in model.children">
+        <component v-bind:is="child.component" v-bind:model="child"></component>
+      </template>
+    </div>
+  </div>
+</template>
+<script>
+  export default {
+    props: ['model'],
+    computed:{
+      icon: function(){
+        let currentState = $perAdminApp.getNodeFromViewOrNull("/state/tools/workspace/view")
+        let foundicon = this.model.icon;
+
+        this.model.children.forEach( function(child){
+          if (child.target === currentState){
+            foundicon = child.icon;
+          }
+        });
+        return foundicon;
+      }
+    }
+  }
+
+</script>
+
+<style scoped>
+  /* The dropdown container */
+  .drpdwn {
+    display: inline-block;
+    vertical-align: middle;
+    height: 40px;
+  }
+
+  /* Dropdown button */
+  .drpbtn {
+    border: none;
+    outline: none;
+    background-color: inherit;
+    margin: 0; /* Important for vertical align on mobile phones */
+    height: inherit;
+  }
+
+  /* Dropdown content (hidden by default) */
+  .drpdwn-content {
+    display: none;
+    position: absolute;
+    max-width: 54px;
+    z-index: 1;
+    padding-top: 1px;
+  }
+
+  /* Add shadow to dropdown content items*/
+  .drpdwn-content span {
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  }
+
+  /* Set line-height for icons inside the navigation bar */
+  .material-icons {
+    line-height: 40px;
+  }
+
+  /* Show the dropdown menu on hover */
+  .drpdwn:hover .drpdwn-content {
+    display: block;
+  }
+</style>

--- a/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/edit/.content.xml
+++ b/admin-base/ui.apps/src/main/content/jcr_root/content/admin/pages/edit/.content.xml
@@ -42,46 +42,8 @@
                 <subnav jcr:primaryType="nt:unstructured"
                   sling:resourceType="admin/components/subnav" classes="navcenter">
 
-                    <mobile jcr:primaryType="nt:unstructured"
-                      sling:resourceType="admin/components/action" target="mobile" type="icon" title="mobile"
-                      stateFrom="/state/tools/workspace/view"
-                      command="editPreview" icon="phone_android">
-                      <experiences jcr:primaryType="nt:unstructured">
-                        <de jcr:primaryType="nt:unstructured" experiences="[lang:de]" title="Mobil"/>
-                      </experiences>
-                    </mobile>
-                    <mobile-landscape jcr:primaryType="nt:unstructured"
-                                      sling:resourceType="admin/components/action"
-                                      target="mobile-landscape"
-                                      type="icon"
-                                      title="mobile-landscape"
-                                      stateFrom="/state/tools/workspace/view"
-                                      command="editPreview"
-                                      icon="stay_current_landscape"/>
-                    <tablet jcr:primaryType="nt:unstructured"
-                      sling:resourceType="admin/components/action" target="tablet" type="icon" title="tablet"
-                      stateFrom="/state/tools/workspace/view"
-                      command="editPreview" icon="tablet_android">
-                      <experiences jcr:primaryType="nt:unstructured">
-                        <de jcr:primaryType="nt:unstructured" experiences="[lang:de]" title="Tablet"/>
-                      </experiences>
-                    </tablet>
-                    <tablet-landscape jcr:primaryType="nt:unstructured"
-                                      sling:resourceType="admin/components/action"
-                                      target="tablet-landscape"
-                                      type="icon"
-                                      title="tablet-landscape"
-                                      stateFrom="/state/tools/workspace/view"
-                                      command="editPreview"
-                                      icon="tablet"/>
-                  <laptop jcr:primaryType="nt:unstructured"
-                          sling:resourceType="admin/components/action"
-                          target="laptop"
-                          type="icon"
-                          title="laptop"
-                          stateFrom="/state/tools/workspace/view"
-                          command="editPreview"
-                          icon="laptop_mac"/>
+                  <screen-dropdown jcr:primaryType="nt:unstructured"
+                    sling:resourceType="admin/components/materialicondropdown" icon="desktop_mac">
                     <desktop jcr:primaryType="nt:unstructured"
                       sling:resourceType="admin/components/action" target="desktop" type="icon" title="desktop"
                       stateFrom="/state/tools/workspace/view" stateFromDefault="true"
@@ -90,6 +52,47 @@
                         <de jcr:primaryType="nt:unstructured" experiences="[lang:de]" title="Desktop"/>
                       </experiences>
                     </desktop>
+                    <laptop jcr:primaryType="nt:unstructured"
+                      sling:resourceType="admin/components/action"
+                      target="laptop"
+                      type="icon"
+                      title="laptop"
+                      stateFrom="/state/tools/workspace/view"
+                      command="editPreview"
+                      icon="laptop_mac"/>
+                    <tablet-landscape jcr:primaryType="nt:unstructured"
+                      sling:resourceType="admin/components/action"
+                      target="tablet-landscape"
+                      type="icon"
+                      title="tablet-landscape"
+                      stateFrom="/state/tools/workspace/view"
+                      command="editPreview"
+                      icon="tablet"/>
+                    <tablet jcr:primaryType="nt:unstructured"
+                      sling:resourceType="admin/components/action" target="tablet" type="icon" title="tablet"
+                      stateFrom="/state/tools/workspace/view"
+                      command="editPreview" icon="tablet_android">
+                      <experiences jcr:primaryType="nt:unstructured">
+                        <de jcr:primaryType="nt:unstructured" experiences="[lang:de]" title="Tablet"/>
+                      </experiences>
+                    </tablet>
+                    <mobile-landscape jcr:primaryType="nt:unstructured"
+                      sling:resourceType="admin/components/action"
+                      target="mobile-landscape"
+                      type="icon"
+                      title="mobile-landscape"
+                      stateFrom="/state/tools/workspace/view"
+                      command="editPreview"
+                      icon="stay_current_landscape"/>
+                    <mobile jcr:primaryType="nt:unstructured"
+                      sling:resourceType="admin/components/action" target="mobile" type="icon" title="mobile"
+                      stateFrom="/state/tools/workspace/view"
+                      command="editPreview" icon="phone_android">
+                      <experiences jcr:primaryType="nt:unstructured">
+                        <de jcr:primaryType="nt:unstructured" experiences="[lang:de]" title="Mobil"/>
+                      </experiences>
+                    </mobile>
+                  </screen-dropdown>
                     <separator jcr:primaryType="nt:unstructured"
                       sling:resourceType="admin/components/separator"/>
                     <ignore-containers jcr:primaryType="nt:unstructured"


### PR DESCRIPTION
- Created a new 'materialicondropdown' component which resembles a dropdown menu, visualized by a material icon.
- The visualization icon depends on the selected item inside the dropdown menu (can have a default icon)
- Wrapped the new dropdown component around the screen width items (dropdown icon equals the currently selected screen width)