### PR TITLE
METDEV-1427: Make screen width dropdown visible in preview mode

### DIFF
--- a/admin-base/materialize/custom/_workspace.scss
+++ b/admin-base/materialize/custom/_workspace.scss
@@ -200,7 +200,6 @@
 		&.preview {
 			width: 100% !important;
 			position: fixed;
-			z-index: 1;
 			top: 112px;
 			bottom: 0;
 			left: 0;

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
@@ -54,7 +54,7 @@
     display: none;
     position: absolute;
     max-width: 54px;
-    z-index: 1;
+    z-index: 1000;
     padding-top: 1px;
   }
 

--- a/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
+++ b/admin-base/ui.apps/src/main/content/jcr_root/apps/admin/components/materialicondropdown/template.vue
@@ -54,7 +54,6 @@
     display: none;
     position: absolute;
     max-width: 54px;
-    z-index: 1000;
     padding-top: 1px;
   }
 


### PR DESCRIPTION
- Adjusted z-index for the workspace in preview mode since navigation and workspace had the same index, thus the dropdown was always below the workspace.